### PR TITLE
Test against top100 URL set

### DIFF
--- a/url/src/test/java/com/tylerkindy/url/UrlTest.java
+++ b/url/src/test/java/com/tylerkindy/url/UrlTest.java
@@ -19,9 +19,13 @@ package com.tylerkindy.url;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
+import com.google.common.io.Resources;
 import com.tylerkindy.url.testdata.TestCase.Failure;
 import com.tylerkindy.url.testdata.TestCase.Success;
 import com.tylerkindy.url.testdata.TestCaseReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.Fail;
@@ -97,5 +101,31 @@ class UrlTest {
 
               throw new IllegalStateException("Unknown TestCase class: " + testCase);
             });
+  }
+
+  @TestFactory
+  Stream<DynamicTest> top100UrlsTests() {
+    List<String> urlStrings;
+    try {
+      urlStrings = Resources.readLines(
+          Resources.getResource("top100.txt"),
+          StandardCharsets.UTF_8
+      );
+    } catch (IOException e) {
+      throw new RuntimeException("Error reading top100.txt", e);
+    }
+
+    return urlStrings
+        .stream()
+        .map(urlString -> dynamicTest(urlString, () -> {
+          UrlParseResult result = Url.parse(urlString);
+
+          assertThat(result)
+              .withFailMessage(() -> "Expected '%s' to parse, but got %s".formatted(
+                  urlString,
+                  result
+              ))
+              .isInstanceOf(UrlParseResult.Success.class);
+        }));
   }
 }

--- a/url/src/test/java/com/tylerkindy/url/UrlTest.java
+++ b/url/src/test/java/com/tylerkindy/url/UrlTest.java
@@ -16,6 +16,7 @@
 
 package com.tylerkindy.url;
 
+import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 
@@ -117,6 +118,7 @@ class UrlTest {
 
     return urlStrings
         .stream()
+        .filter(not(String::isEmpty))
         .map(urlString -> dynamicTest(urlString, () -> {
           UrlParseResult result = Url.parse(urlString.replaceAll("\\\\n", "\n"));
 

--- a/url/src/test/java/com/tylerkindy/url/UrlTest.java
+++ b/url/src/test/java/com/tylerkindy/url/UrlTest.java
@@ -118,7 +118,7 @@ class UrlTest {
     return urlStrings
         .stream()
         .map(urlString -> dynamicTest(urlString, () -> {
-          UrlParseResult result = Url.parse(urlString);
+          UrlParseResult result = Url.parse(urlString.replaceAll("\\\\n", "\n"));
 
           assertThat(result)
               .withFailMessage(() -> "Expected '%s' to parse, but got %s".formatted(


### PR DESCRIPTION
The Ada implementers have [a dataset](https://github.com/ada-url/url-various-datasets/tree/96a6fdd1e36a98904025ed5d1efd5ac9375bc18c/top100) of ~100k unique URLs found on the top 100 sites. A nice addition to my test suite.

Not all of them are valid according to the spec. Those ones are just clearly wrong, so I cleaned them up or deleted them from the dataset.